### PR TITLE
Update sadcloud for 2024

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -4,7 +4,7 @@ resource "aws_eks_cluster" "example" {
   version =  var.out_of_date ? "1.14" : null
 
   vpc_config {
-    subnet_ids =  ["${var.main_subnet_id}","${var.secondary_subnet_id}"]
+    subnet_ids =  [var.main_subnet_id,var.secondary_subnet_id]
     endpoint_public_access = var.publicly_accessible
     # public_access_cidrs = "${var.globally_accessible ? ["0.0.0.0/0"] : ["127.0.0.0/8"]}"
   }

--- a/modules/aws/elbv2/main.tf
+++ b/modules/aws/elbv2/main.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "access_logging" {
 resource "aws_lb" "main" {
   load_balancer_type = "application"
   enable_deletion_protection = !var.no_deletion_protection
-  subnets = ["${var.main_subnet_id}","${var.secondary_subnet_id}"]
+  subnets = [var.main_subnet_id,var.secondary_subnet_id]
 
   access_logs {
     bucket  = aws_s3_bucket.access_logging[0].bucket_prefix

--- a/modules/aws/elbv2/main.tf
+++ b/modules/aws/elbv2/main.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "access_logging" {
   bucket_prefix = var.name
-  acl    = "private"
   force_destroy = true
 
   count = var.no_access_logs && (var.no_deletion_protection || var.older_ssl_policy) ? 1 : 0

--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -52,6 +52,8 @@ EOF
 
 resource "aws_iam_role" "inline_role" {
 
+  name_prefix = "sadcloud-inline-role-policy-"
+
   count = var.inline_role_policy ? 1 : 0
 
   assume_role_policy = <<EOF

--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -94,9 +94,16 @@ resource "aws_iam_role_policy" "inline_role_policy" {
 EOF
 }
 
-resource "aws_iam_role" "allow_all" {
+resource "aws_iam_role" "trust_all_with_mfa" {
 
   count = (var.assume_role_policy_allows_all && !var.assume_role_no_mfa) ? 1 : 0
+
+  name_prefix = "sadcloud-trust-all-with-mfa-"
+
+  inline_policy {
+    name = "deny-all"
+    policy = data.aws_iam_policy_document.deny_all.json
+  }
 
   assume_role_policy = <<EOF
 {
@@ -120,9 +127,16 @@ resource "aws_iam_role" "allow_all" {
 EOF
 }
 
-resource "aws_iam_role" "allow_all_and_no_mfa" {
+resource "aws_iam_role" "trust_all_without_mfa" {
 
   count = (var.assume_role_policy_allows_all && var.assume_role_no_mfa) ? 1 : 0
+
+  name_prefix = "sadcloud-trust-all-without-mfa-"
+
+  inline_policy {
+    name = "deny-all"
+    policy = data.aws_iam_policy_document.deny_all.json
+  }
 
   assume_role_policy = <<EOF
 {
@@ -211,4 +225,12 @@ resource "aws_iam_group_policy_attachment" "admin_not_indicated_policy-attach" {
   group = aws_iam_group.admin_not_indicated[0].id
   policy_arn = aws_iam_policy.admin_not_indicated_policy[0].arn
   count = var.admin_not_indicated_policy ? 1 : 0
+}
+
+data "aws_iam_policy_document" "deny_all" {
+  statement {
+    effect = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+  }
 }

--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_group" "inline_group" {
-  name = "sadcloudInlineGroup"
+  name = "sadcloud-inline-group"
 
   count = var.inline_group_policy ? 1 : 0
 }
@@ -26,7 +26,7 @@ EOF
 }
 
 resource "aws_iam_user" "inline_user" {
-  name = "sadcloudInlineUser"
+  name = "sadcloud-inline-user"
 
   count = var.inline_user_policy ? 1 : 0
 }
@@ -177,7 +177,7 @@ resource "aws_iam_account_password_policy" "main" {
 resource "aws_iam_policy" "policy" {
   count = var.admin_iam_policy ? 1 : 0
 
-  name_prefix = "wildcard_IAM_policy"
+  name_prefix = "sadcloud-wildcard_IAM_policy"
   path        = "/"
 
   policy = <<EOF
@@ -197,7 +197,7 @@ EOF
 resource "aws_iam_group" "admin_not_indicated" {
   count = var.admin_not_indicated_policy ? 1 : 0
 
-  name = "sadcloud_superuser"
+  name = "sadcloud-superuser"
   path = "/"
 }
 
@@ -207,7 +207,7 @@ resource "aws_iam_policy" "admin_not_indicated_policy" {
   count = var.admin_not_indicated_policy ? 1 : 0
 
 
-  name  = "sadcloud_superuser_policy"
+  name  = "sadcloud-superuser-policy"
 
   policy = <<EOF
 {

--- a/modules/aws/iam/variables.tf
+++ b/modules/aws/iam/variables.tf
@@ -7,7 +7,7 @@ variable "name" {
 ############## Findings ##############
 
 variable "password_policy_minimum_length" {
-  description = "insufficient minumum length"
+  description = "insufficient minimum length"
   type        = bool
   default     = false
 }

--- a/modules/aws/kms/main.tf
+++ b/modules/aws/kms/main.tf
@@ -30,7 +30,7 @@ resource "aws_kms_key" "exposed" {
   "Id": "key-insecure-1",
   "Statement": [
     {
-      "Sid": "Enable root suer and identity policies",
+      "Sid": "Enable root user and identity policies",
       "Effect": "Allow",
       "Principal": {"AWS" : "${local.account_root_user_arn}"},
       "Action": "kms:*",

--- a/modules/aws/kms/main.tf
+++ b/modules/aws/kms/main.tf
@@ -5,14 +5,14 @@ locals {
 }
 
 resource "aws_kms_key" "main" {
-  description             = "sadcloud key"
+  description             = "sadcloud unrotated key"
   enable_key_rotation = !var.key_rotation_disabled
 
   count = var.key_rotation_disabled ? 1 : 0
 }
 
 resource "aws_kms_alias" "main" {
-  name          = "alias/unrotated"
+  name          = "alias/sadcloud-unrotated"
   target_key_id = aws_kms_key.main[0].key_id
 
   count = var.key_rotation_disabled ? 1 : 0
@@ -53,7 +53,7 @@ EOF
 }
 
 resource "aws_kms_alias" "exposed" {
-  name          = "alias/exposed"
+  name          = "alias/sadcloud-exposed"
   target_key_id = aws_kms_key.exposed[0].key_id
 
   count = var.kms_key_exposed ? 1 : 0

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "main" {
   storage_type         = "gp2"
   engine               = "mysql"
   instance_class       = "db.t2.micro"
-  name                 = var.name
+  db_name              = var.name
   username             = "foo"
   password             = "foobarbaz"
   skip_final_snapshot = true

--- a/sadcloud/terraform.tfvars
+++ b/sadcloud/terraform.tfvars
@@ -7,6 +7,7 @@ all_ec2_findings = false
 all_elb_findings = false
 all_elbv2_findings = false
 all_iam_findings = false
+all_kms_findings = false
 all_rds_findings = false
 all_redshift_findings = false
 all_s3_findings = false

--- a/sadcloud/terraform.tfvars
+++ b/sadcloud/terraform.tfvars
@@ -6,6 +6,7 @@ all_config_findings = false
 all_ec2_findings = false
 all_elb_findings = false
 all_elbv2_findings = false
+all_eks_findings = false
 all_iam_findings = false
 all_kms_findings = false
 all_rds_findings = false


### PR DESCRIPTION
Update sadcloud to work with modern versions of Terraform and AWS 2024 (S3) configs.

Tested:
Terraform: 0.13.7, 1.5.7
Modules: IAM, S3, KMS

Address deprecations and source-level incompatibilities across sadcloud for tested Terraform versions.

Also:

* improve naming of resources in tested modules (IAM, S3, KMS)
* adjust security policies to reduce risk of accidents & abuse
